### PR TITLE
Routes: Provide naming and cleanup

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,75 +4,216 @@ Route::middleware(['auth'])->group(function () {
   Route::get('/', 'ClassesController@index');
 
   //Admin tables
-  Route::get('/admin/tables', 'AdminTablesController@index');
+  Route::get('/admin/tables', [
+    'as' => 'admin.tables',
+    'uses' => 'AdminTablesController@index'
+  ]);
 
   //Family routes
-  Route::get('/families', 'FamiliesController@index');
-  Route::get('/families/{family}', 'FamiliesController@edit');
+  Route::get('/families', [
+    'as' => 'families',
+    'uses' => 'FamiliesController@index'
+  ]);
+  Route::get('/families/{family}', [
+    'as' => 'families.edit',
+    'uses' => 'FamiliesController@edit'
+  ]);
 
   //Student routes
-  Route::get('/students', 'StudentsController@index');
-  Route::get('/students/{student}', 'StudentsController@edit');
-  Route::get('/families/{family}/student/create', 'StudentsController@create');
+  Route::get('/students', [
+    'as' => 'students',
+    'uses' => 'StudentsController@index'
+  ]);
+  Route::get('/students/{student}', [
+    'as' => 'students.edit',
+    'uses' => 'StudentsController@edit'
+  ]);
+  Route::get('student/create', [
+    'as' => 'students.create',
+    'uses' => 'StudentsController@create'
+  ]);
 
   //Class routes
-  Route::get('/classes', 'ClassesController@index');
-  Route::get('/classes/create', 'ClassesController@create');
-  Route::get('/classes/{class}', 'ClassesController@show');
+  Route::get('/classes', [
+    'as' => 'classes',
+    'uses' => 'ClassesController@index'
+  ]);
+  Route::get('/classes/create', [
+    'as' => 'classes.create',
+    'uses' => 'ClassesController@create'
+  ]);
+  Route::get('/classes/{class}', [
+    'as' => 'classes.show',
+    'uses' => 'ClassesController@show'
+  ]);
 
   //Season routes
-  Route::get('/seasons', 'SeasonsController@index');
-  Route::get('/seasons/{season}', 'SeasonsController@show');
-  Route::get('/seasons/{season}/edit', 'SeasonsController@edit');
-  Route::get('/seasons/{season}/delete', 'SeasonsController@destroy');
-  Route::post('/seasons', 'SeasonsController@store');
-  Route::post('/seasons/{season}', 'SeasonsController@update');
+  Route::get('/seasons', [
+    'as' => 'seasons',
+    'uses' => 'SeasonsController@index'
+  ]);
+  Route::get('/seasons/{season}', [
+    'as' => 'seasons.show',
+    'uses' => 'SeasonsController@show'
+  ]);
+  Route::get('/seasons/{season}/edit', [
+    'as' => 'seasons.edit',
+    'uses' => 'SeasonsController@edit'
+  ]);
+  //  THIS SHOULD BE A POST REQUEST
+  Route::get('/seasons/{season}/delete', [
+    'as' => 'seasons.delete',
+    'uses' => 'SeasonsController@destroy'
+  ]);
+  //  Should this be create?
+  Route::post('/seasons', [
+    'as' => 'seasons.store',
+    'uses' => 'SeasonsController@store'
+  ]);
+  Route::post('/seasons/{season}', [
+    'as' => 'seasons.edit',
+    'uses' => 'SeasonsController@update'
+  ]);
   //Route::resource('seasons', 'SeasonsController');
 
   //Session routes
-  Route::get('/sessions', 'SessionsController@index');
-  Route::get('/sessions/{session}', 'SessionsController@show');
-  Route::get('/sessions/{session}/edit', 'SessionsController@edit');
-  Route::post('/sessions', 'SessionsController@store');
-  Route::post('/sessions/{session}', 'SessionsController@update');
+  Route::get('/sessions', [
+    'as' => 'sessions',
+    'uses' => 'SessionsController@index'
+  ]);
+  Route::get('/sessions/{session}', [
+    'as' => 'sessions.show',
+    'uses' => 'SessionsController@show'
+  ]);
+  Route::get('/sessions/{session}/edit', [
+    'as' => 'sessions.edit',
+    'uses' => 'SessionsController@edit'
+  ]);
+  Route::post('/sessions', [
+    'as' => 'sessions.store',
+    'uses' => 'SessionsController@store'
+  ]);
+  Route::post('/sessions/{session}', [
+    'as' => 'sessions.update',
+    'uses' => 'SessionsController@update'
+  ]);
 
   //Class-type routes
-  Route::get('/classtypes', 'ClassTypesController@index');
-  Route::get('/classtypes/{classtype}', 'ClassTypesController@show');
-  Route::get('/classtypes/{classtype}/edit', 'ClassTypesController@edit');
-  Route::post('/classtypes', 'ClassTypesController@store');
-  Route::post('/classtypes/{classtype}', 'ClassTypesController@update');
+  Route::get('/classtypes', [
+    'as' => 'classtypes',
+    'uses' => 'ClassTypesController@index'
+  ]);
+  Route::get('/classtypes/{classtype}', [
+    'as' => 'classtypes.show',
+    'uses' => 'ClassTypesController@show'
+  ]);
+  Route::get('/classtypes/{classtype}/edit', [
+    'as' => 'classtypes.edit',
+    'uses' => 'ClassTypesController@edit'
+  ]);
+  Route::post('/classtypes', [
+    'as' => 'classtypes.store',
+    'uses' => 'ClassTypesController@store'
+  ]);
+  Route::post('/classtypes/{classtype}', [
+    'as' => 'classtypes.update',
+    'uses' => 'ClassTypesController@update'
+  ]);
 
   //Address-type routes
-  Route::get('/addresstypes', 'AddressTypesController@index');
-  Route::get('/addresstypes/{addresstype}', 'AddressTypesController@show');
-  Route::get('/addresstypes/{addresstype}/edit', 'AddressTypesController@edit');
-  Route::post('/addresstypes', 'AddressTypesController@store');
-  Route::post('/addresstypes/{addresstype}', 'AddressTypesController@update');
+  Route::get('/addresstypes', [
+    'as' => 'addresstypes',
+    'uses' => 'AddressTypesController@index'
+  ]);
+  Route::get('/addresstypes/{addresstype}', [
+    'as' => 'addresstypes.show',
+    'uses' => 'AddressTypesController@show'
+  ]);
+  Route::get('/addresstypes/{addresstype}/edit', [
+    'as' => 'addresstypes.edit',
+    'uses' => 'AddressTypesController@edit'
+  ]);
+  Route::post('/addresstypes', [
+    'as' => 'addresstypes.store',
+    'uses' => 'AddressTypesController@store'
+  ]);
+  Route::post('/addresstypes/{addresstype}', [
+    'as' => 'addresstypes.update',
+    'uses' => 'AddressTypesController@update'
+  ]);
 
   //Location routes
-  Route::get('/locations', 'LocationsController@index');
-  Route::get('/locations/{location}', 'LocationsController@show');
-  Route::get('/locations/{location}/edit', 'LocationsController@edit');
-  Route::post('/locations', 'LocationsController@store');
-  Route::post('/locations/{location}', 'LocationsController@update');
+  Route::get('/locations', [
+    'as' => 'locations',
+    'uses' => 'LocationsController@index'
+  ]);
+  Route::get('/locations/{location}', [
+    'as' => 'locations.show',
+    'uses' => 'LocationsController@show'
+  ]);
+  Route::get('/locations/{location}/edit', [
+    'as' => 'locations.edit',
+    'uses' => 'LocationsController@edit'
+  ]);
+  Route::post('/locations', [
+    'as' => 'locations.store',
+    'uses' => 'LocationsController@store'
+  ]);
+  Route::post('/locations/{location}', [
+    'as' => 'locationsupdate',
+    'uses' => 'LocationsController@update'
+  ]);
 
   //Phone-type routes
-  Route::get('/phonetypes', 'PhoneTypesController@index');
-  Route::get('/phonetypes/{phonetype}', 'PhoneTypesController@show');
-  Route::get('/phonetypes/{phonetype}/edit', 'PhoneTypesController@edit');
-  Route::post('/phonetypes', 'PhoneTypesController@store');
-  Route::post('/phonetypes/{phonetype}', 'PhoneTypesController@update');
+  Route::get('/phonetypes', [
+    'as' => 'phonetypes',
+    'uses' => 'PhoneTypesController@index'
+  ]);
+  Route::get('/phonetypes/{phonetype}', [
+    'as' => 'phonetypes.show',
+    'uses' => 'PhoneTypesController@show'
+  ]);
+  Route::get('/phonetypes/{phonetype}/edit', [
+    'as' => 'phonetypes.edit',
+    'uses' => 'PhoneTypesController@edit'
+  ]);
+  Route::post('/phonetypes', [
+    'as' => 'phonetypes.store',
+    'uses' => 'PhoneTypesController@store'
+  ]);
+  Route::post('/phonetypes/{phonetype}', [
+    'as' => 'phonetypes.update',
+    'uses' => 'PhoneTypesController@update'
+  ]);
 
   //Rate routes
-  Route::get('/rates', 'RatesController@index');
-  Route::get('/rates/{rate}', 'RatesController@show');
-  Route::get('/rates/{rate}/edit', 'RatesController@edit');
-  Route::post('/rates', 'RatesController@store');
-  Route::post('/rates/{rate}', 'RatesController@update');
+  Route::get('/rates', [
+    'as' => 'rates',
+    'uses' => 'RatesController@index'
+  ]);
+  Route::get('/rates/{rate}', [
+    'as' => 'rates.show',
+    'uses' => 'RatesController@show'
+  ]);
+  Route::get('/rates/{rate}/edit', [
+    'as' => 'rates.edit',
+    'uses' => 'RatesController@edit'
+  ]);
+  Route::post('/rates', [
+    'as' => 'rates.store',
+    'uses' => 'RatesController@store'
+  ]);
+  Route::post('/rates/{rate}', [
+    'as' => 'rates.update',
+    'uses' => 'RatesController@update'
+  ]);
 
   //Sortable route
-  Route::post('/sort', '\Rutorika\Sortable\SortableController@sort');
+  //This is bad work. Shouldn't ever bind a route to a 3rd party library or package route
+  Route::post('/sort', [
+    'as' => 'sort',
+    'uses' => '\Rutorika\Sortable\SortableController@sort'
+  ]);
 });
 
 


### PR DESCRIPTION
PR cleans up the routes and provides named routes. In the arrays the keyword `as` is an alias for the `name` function in the current documentation for routes.

By specifying a name to the routes, you can simplify link create and redirection by only needing to remember the naming convention. Examples of use include

`$redirect = redirect()->route('classtypes.show', 50);`
`<form method="post" action="{{ route('families.edit', $family->id) }}">`

Also, I took the route for `students.create` and removed the routing through families. Shouldn't have to pass a family ID through the route to associate a user created to a family. If this is an administrative section, you can pass the family ID through a form element instead.