### PR TITLE
Clean up Seasons Views

### DIFF
--- a/app/Http/Controllers/ClassesController.php
+++ b/app/Http/Controllers/ClassesController.php
@@ -22,7 +22,18 @@ class ClassesController extends Controller
         }
         $seasons = Season::where('Archived', 0)->orderBy('Order', 'asc')->get();
         $daysOfWeek = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
-        return view('classes.index', compact('classes', 'seasons', 'season', $daysOfWeek));
+
+        /*  It's better to explicitly set the data being passed into the view
+            If a variable that is undefined or null is passed to the compact function
+            it will basically insert a null pointer into the compacted object and break
+            everything compacted afterwards.
+        */
+        return view('classes.index', [
+            'classes' => $classes,
+            'seasons' => $seasons,
+            'season' => $season,
+            'daysOfWeek' => $daysOfWeek
+        ]);
     }
 
     /**

--- a/resources/views/classes/index.blade.php
+++ b/resources/views/classes/index.blade.php
@@ -7,8 +7,8 @@
 				<div class="tabs">
 					<ul>
 					@foreach ($seasons as $seasonTemp)
-						<li @if ($season->id == $seasonTemp->id) class="is-active" @endif>
-							<a href="/classes/season/{{$seasonTemp->id}}">{{$seasonTemp->Name}}</a>
+						<li {{ $season->id === $seasonTemp->id ? 'class="is-active"' : '' }}>
+							<a href="{{ route('classes.season', $seasonTemp->id) }}">{{$seasonTemp->Name}}</a>
 						</li>
 					@endforeach
 					</ul>
@@ -21,7 +21,7 @@
 						@foreach ($classes as $class)
 							@if ($class->DayHeldOn == $day)
 								<p class="is-size-6 is-paddingless is-marginless">
-									<a href="/classes/{{$class->id}}">{{ $class->Name}}</a>
+									<a href="{{ route('classes.show', $chass->id) }}">{{ $class->Name}}</a>
 								</p>
 								<p class="is-size-7 is-paddingless is-marginless">
 									<span style="display:inline-block;">
@@ -61,11 +61,22 @@
 						@if ($i == 1)
 						<div class="column">
 						@endif
-							<p class="is-size-6 is-paddingless is-marginless"><a href="/classes/{{$class->id}}">{{ $class->Name}}</a></p>
+							<p class="is-size-6 is-paddingless is-marginless">
+								<a href="{{ route('classes.show', $class->id) }}">{{ $class->Name}}</a>
+							</p>
 							<p class="is-size-7 is-paddingless is-marginless">
-								<span style="display:inline-block;"><i class="fa fa-user-circle" aria-hidden="true"></i> {{$class->instructor->Display}}</span> /
-								<span style="display:inline-block;"><i class="fa fa-map-marker" aria-hidden="true"></i> {{$class->location->Type}}</span> /
-								<span style="display:inline-block;"><i class="fa fa-user" aria-hidden="true"></i> Ages {{$class->AgeFrom}} to {{$class->AgeTo}}</span>
+								<span style="display:inline-block;">
+									<i class="fa fa-user-circle" aria-hidden="true"></i>
+									{{$class->instructor->Display}}
+								</span> /
+								<span style="display:inline-block;">
+									<i class="fa fa-map-marker" aria-hidden="true"></i>
+									{{$class->location->Type}}
+								</span> /
+								<span style="display:inline-block;">
+									<i class="fa fa-user" aria-hidden="true"></i>
+									Ages {{$class->AgeFrom}} to {{$class->AgeTo}}
+								</span>
 								@foreach ($class->dates as $classdate)
 									<p class="is-size-7 is-paddingless is-marginless">
 										<i class="fa fa-calendar-check-o" aria-hidden="true"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,7 @@ Route::middleware(['auth'])->group(function () {
     'uses' => 'ClassesController@show'
   ]);
   Route::get('/classes/season/{season}', [
-        'as' => 'classes',
+        'as' => 'classes.season',
         'uses' => 'ClassesController@index'
     ]);
 


### PR DESCRIPTION
I tried to clean up all of the PHP work in the classes view, but it's too complex and doing a lot. I'm not sure this is the best way to go about making either the list view or the calendar view.

The list view could be achieved in a table or a panel element. Or possibly some other component in that extensions project mentioned in slack.

For the calendar view, we could go with https://wikiki.github.io/components/calendar/. It's included in the extensions project by default. The calendar looks awfully similar to the list view as well and I don't see a huge reason to have both. I'll spend some time working out another type of view that I think is manageable and easy on the eyes