### PR TITLE
Fixes for class dates and enrollments. Class seeding as well.

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -134,6 +134,13 @@ $factory->define(App\Student::class, function($faker) {
 });
 
 $factory->define(App\Enrollment::class, function($faker) {
+  $class = App\Classes::inRandomOrder()->first();
+  $season = $class->season()->first();
+  $classdate = new App\ClassDate;
+  if ($season->SeasonType == 2) {
+    $classdate = App\ClassDate::where('classes_id', $class->id)->inRandomOrder()->first();
+  }
+
   $dropped = $faker->optional(0.2, 0)->numberBetween(0, 1);
   $droppedOn = null;
   $enrolledOn = null;
@@ -144,7 +151,8 @@ $factory->define(App\Enrollment::class, function($faker) {
     $enrolledOn = $faker->dateTimeInInterval($droppedOn, '-1 year')->format('Y-m-d');
   }
   return [
-    'class_id' => App\Classes::inRandomOrder()->first(),
+    'classes_id' => $class->id,
+    'class_dates_id' => $classdate->id,
     'Dropped' => $dropped,
     'EnrolledOn' => $enrolledOn,
     'DroppedOn' => $droppedOn,

--- a/database/migrations/2017_10_12_133949_create_enrollments_table.php
+++ b/database/migrations/2017_10_12_133949_create_enrollments_table.php
@@ -16,7 +16,8 @@ class CreateEnrollmentsTable extends Migration
         Schema::create('enrollments', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('student_id');
-            $table->integer('class_id');
+            $table->integer('classes_id');
+            $table->integer('class_dates_id')->nullable();
             $table->integer('Dropped')->nullable();
             $table->dateTime('EnrolledOn')->nullable();
             $table->dateTime('DroppedOn')->nullable();

--- a/database/seeds/SeasonsTableSeeder.php
+++ b/database/seeds/SeasonsTableSeeder.php
@@ -16,8 +16,12 @@ class SeasonsTableSeeder extends Seeder
 
         foreach ($seasons as $season) {
             $howManyClasses = rand(10, 30);
+            if ($season->SeasonType == 1) {
+              $season->classes()->saveMany(factory(App\Classes::class, $howManyClasses)->make(['season_id'=>$season->id]));
+            } elseif ($season->SeasonType == 2) {
+              $season->classes()->saveMany(factory(App\Classes::class, $howManyClasses)->make(['season_id'=>$season->id, 'DayHeldOn'=>null, 'StartTime'=>null, 'Length'=>null ]));
+            }
 
-            $season->classes()->saveMany(factory(App\Classes::class, $howManyClasses)->make(['season_id'=>$season->id]));
             if ($season->SeasonType == 2) {
                 foreach ($season->classes as $class) {
                     $howManyDates = rand(1,5);


### PR DESCRIPTION
Adding a class_dates_id to enrollments, change seeding to leave class fields null for date-specific classes and enroll student in both weekly and date-specific classes.