### PR TITLE
Existing enrollment actions

### DIFF
--- a/app/ClassDate.php
+++ b/app/ClassDate.php
@@ -26,7 +26,12 @@ class ClassDate extends Model
 
     public function enrollments()
     {
-        return $this->hasMany(Enrollment::class, 'class_dates_id')->orderBy('HeldOn')->orderBy('StartTime');
+        return $this->morphMany('App\Enrollment', 'enrollable');
+    }
+
+    public function class()
+    {
+        return $this->belongsTo(Classes::class, 'classes_id');
     }
 
 }

--- a/app/ClassDay.php
+++ b/app/ClassDay.php
@@ -9,9 +9,14 @@ class ClassDay extends Model
 {
     protected $table = 'class_days';
 
-    public function classes()
+    public function class()
     {
-        return $this->belongsToMany(Classes::class, 'id');
+        return $this->belongsTo(Classes::class, 'classes_id');
+    }
+
+    public function enrollments()
+    {
+        return $this->morphMany('App\Enrollment', 'enrollable');
     }
 
 }

--- a/app/Enrollment.php
+++ b/app/Enrollment.php
@@ -4,25 +4,48 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class Enrollment extends Model
 {
-    public function enrollable()
-    {
-        return $this->morphTo();
-    }
+  public function enrollable()
+  {
+    return $this->morphTo();
+  }
 
-    public function student() {
-        return $this->belongsTo(Student::class, 'student_id');
-    }
+  public function student() {
+    return $this->belongsTo(Student::class, 'student_id');
+  }
 
-    public function friendlyDate($date)
-    {
-        if (isset($date)) {
-            return (Carbon::parse($date)->format('D\, M\. jS Y'));
-        } else {
-            return null;
-        }
-        
+  public function friendlyDate($date)
+  {
+    if (isset($date)) {
+      return (Carbon::parse($date)->format('D\, M\. jS Y'));
+    } else {
+      return null;
     }
+      
+  }
+
+  public function otherEnrollmentsInClass(Enrollment $enrollment)
+  {
+    if ($enrollment->enrollable->class->season->SeasonType == 1) {
+      $otherEnrollments = DB::table('class_days')
+        ->join('enrollments', 'class_days.id', '=', 'enrollments.enrollable_id')
+        ->where([
+          ['enrollments.enrollable_type', '=', 'App\ClassDay'],
+          ['enrollments.student_id', '=', $enrollment->student_id],
+          ['class_days.classes_id', '=', $enrollment->enrollable->classes_id],
+        ])->get();
+    } else {
+      $otherEnrollments = DB::table('class_dates')
+        ->join('enrollments', 'class_dates.id', '=', 'enrollments.enrollable_id')
+        ->where([
+          ['enrollments.enrollable_type', '=', 'App\ClassDate'],
+          ['enrollments.student_id', '=', $enrollment->student_id],
+          ['class_dates.classes_id', '=', $enrollment->enrollable->classes_id],
+        ])->get();
+    }    
+    return ($otherEnrollments);
+  }
 }

--- a/app/Enrollment.php
+++ b/app/Enrollment.php
@@ -26,26 +26,5 @@ class Enrollment extends Model
     }
       
   }
-
-  public function otherEnrollmentsInClass(Enrollment $enrollment)
-  {
-    if ($enrollment->enrollable->class->season->SeasonType == 1) {
-      $otherEnrollments = DB::table('class_days')
-        ->join('enrollments', 'class_days.id', '=', 'enrollments.enrollable_id')
-        ->where([
-          ['enrollments.enrollable_type', '=', 'App\ClassDay'],
-          ['enrollments.student_id', '=', $enrollment->student_id],
-          ['class_days.classes_id', '=', $enrollment->enrollable->classes_id],
-        ])->get();
-    } else {
-      $otherEnrollments = DB::table('class_dates')
-        ->join('enrollments', 'class_dates.id', '=', 'enrollments.enrollable_id')
-        ->where([
-          ['enrollments.enrollable_type', '=', 'App\ClassDate'],
-          ['enrollments.student_id', '=', $enrollment->student_id],
-          ['class_dates.classes_id', '=', $enrollment->enrollable->classes_id],
-        ])->get();
-    }    
-    return ($otherEnrollments);
-  }
+  
 }

--- a/app/Enrollment.php
+++ b/app/Enrollment.php
@@ -15,8 +15,17 @@ class Enrollment extends Model
         return $this->belongsTo(ClassDate::class, 'class_dates_id');
     }
 
+    public function student() {
+        return $this->belongsTo(Student::class, 'student_id');
+    }
+
     public function friendlyDate($date)
     {
-        return (Carbon::parse($date)->format('D\, M\. jS Y'));
+        if (isset($date)) {
+            return (Carbon::parse($date)->format('D\, M\. jS Y'));
+        } else {
+            return null;
+        }
+        
     }
 }

--- a/app/Enrollment.php
+++ b/app/Enrollment.php
@@ -7,12 +7,9 @@ use Carbon\Carbon;
 
 class Enrollment extends Model
 {
-    public function class() {
-        return $this->belongsTo(Classes::class, 'classes_id');
-    }
-
-    public function date() {
-        return $this->belongsTo(ClassDate::class, 'class_dates_id');
+    public function enrollable()
+    {
+        return $this->morphTo();
     }
 
     public function student() {

--- a/app/Http/Controllers/EnrollmentsController.php
+++ b/app/Http/Controllers/EnrollmentsController.php
@@ -7,6 +7,7 @@ use App\Student;
 use App\Family;
 use Illuminate\Http\Request;
 use DateTime;
+use Illuminate\Support\Facades\DB;
 
 class EnrollmentsController extends Controller
 {
@@ -63,11 +64,27 @@ class EnrollmentsController extends Controller
     $students = Student::getActive();
     $families = Family::getActive();
     $inactiveStudents = Student::getInactive();
-      return view('enrollments.edit', [
+    $daysEnrolledInClass = DB::table('class_days')
+      ->join('enrollments', 'class_days.id', '=', 'enrollments.enrollable_id')
+      ->where([
+        ['enrollments.enrollable_type', '=', 'App\ClassDay'],
+        ['enrollments.student_id', '=', $enrollment->student_id],
+        ['class_days.classes_id', '=', $enrollment->enrollable->classes_id],
+      ])->get();
+    $datesEnrolledInClass = DB::table('class_dates')
+      ->join('enrollments', 'class_dates.id', '=', 'enrollments.enrollable_id')
+      ->where([
+        ['enrollments.enrollable_type', '=', 'App\ClassDate'],
+        ['enrollments.student_id', '=', $enrollment->student_id],
+        ['class_dates.classes_id', '=', $enrollment->enrollable->classes_id],
+      ])->get();
+    return view('enrollments.edit', [
         'enrollment' => $enrollment,
         'students' => $students,
         'families' => $families,
-        'inactiveStudents' => $inactiveStudents
+        'inactiveStudents' => $inactiveStudents,
+        'datesEnrolledInClass' => $datesEnrolledInClass,
+        'daysEnrolledInClass' => $daysEnrolledInClass
       ]);        
     }
 

--- a/app/Http/Controllers/EnrollmentsController.php
+++ b/app/Http/Controllers/EnrollmentsController.php
@@ -3,9 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Enrollment;
+use App\Student;
+use App\Family;
 use Illuminate\Http\Request;
+use DateTime;
 
-class EnrollmentController extends Controller
+class EnrollmentsController extends Controller
 {
     /**
      * Display a listing of the resource.
@@ -57,7 +60,15 @@ class EnrollmentController extends Controller
      */
     public function edit(Enrollment $enrollment)
     {
-        //
+    $students = Student::getActive();
+    $families = Family::getActive();
+    $inactiveStudents = Student::getInactive();
+      return view('enrollments.edit', [
+        'enrollment' => $enrollment,
+        'students' => $students,
+        'families' => $families,
+        'inactiveStudents' => $inactiveStudents
+      ]);        
     }
 
     /**

--- a/app/Http/Controllers/EnrollmentsController.php
+++ b/app/Http/Controllers/EnrollmentsController.php
@@ -8,6 +8,7 @@ use App\Family;
 use Illuminate\Http\Request;
 use DateTime;
 use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class EnrollmentsController extends Controller
 {
@@ -97,7 +98,15 @@ class EnrollmentsController extends Controller
      */
     public function update(Request $request, Enrollment $enrollment)
     {
-        //
+      $validated = $request->validate([
+        'EnrolledOn' => 'required',
+        'StartChargingOn' => 'required'
+      ]);
+      $enrollment['EnrolledOn'] = Carbon::parse($validated['EnrolledOn']);
+      $enrollment['StartChargingOn'] = Carbon::parse($validated['StartChargingOn']);
+      $enrollment->save();
+      $request->session()->flash('alert-success', 'Enrollment saved successfully!');
+      return redirect()->route('students.edit', $enrollment->student_id);
     }
 
     /**
@@ -108,6 +117,10 @@ class EnrollmentsController extends Controller
      */
     public function destroy(Enrollment $enrollment)
     {
-        //
+        $enrollment['Dropped'] = 1;
+        $enrollment['DroppedOn'] = Carbon::now();
+        $enrollment->save();
+        $request->session()->flash('alert-success', 'Dropped enrollment successfully!');
+        return redirect()->route('students.edit', $enrollment->student_id);
     }
 }

--- a/app/Student.php
+++ b/app/Student.php
@@ -29,6 +29,11 @@ class Student extends Model
         }
     }
 
+    public function name()
+    {
+        return $this->First . ' ' . $this->Last;
+    }
+
     public static function getActive()
     {
         return Student::where('Active', 1)->orderBy('Last', 'asc')->orderBy('First', 'asc')->get();

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -137,9 +137,16 @@ $factory->define(App\Student::class, function($faker) {
 $factory->define(App\Enrollment::class, function($faker) {
   $class = App\Classes::inRandomOrder()->first();
   $season = $class->season()->first();
-  $classdate = new App\ClassDate;
+  $enrollable_id = '';
+  $enrollable_type = '';
   if ($season->SeasonType == 2) {
     $classdate = App\ClassDate::where('classes_id', $class->id)->inRandomOrder()->first();
+    $enrollable_id = $classdate->id;
+    $enrollable_type = 'App\ClassDate';
+  } elseif ($season->SeasonType == 1) {
+    $classday = App\ClassDay::where('classes_id', $class->id)->inRandomOrder()->first();
+    $enrollable_id = $classday->id;
+    $enrollable_type = 'App\ClassDay';
   }
 
   $dropped = $faker->optional(0.2, 0)->numberBetween(0, 1);
@@ -152,11 +159,11 @@ $factory->define(App\Enrollment::class, function($faker) {
     $enrolledOn = $faker->dateTimeInInterval($droppedOn, '-1 year')->format('Y-m-d');
   }
   return [
-    'classes_id' => $class->id,
-    'class_dates_id' => $classdate->id,
-    'Dropped' => $dropped,
+    'enrollable_id' => $enrollable_id,
+    'enrollable_type' => $enrollable_type,
     'EnrolledOn' => $enrolledOn,
     'StartChargingOn' => $enrolledOn,
+    'Dropped' => $dropped,
     'DroppedOn' => $droppedOn,
     'Active' => $faker->optional(0.2, 1)->numberBetween($min = 0, $max = 1)
   ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -156,6 +156,7 @@ $factory->define(App\Enrollment::class, function($faker) {
     'class_dates_id' => $classdate->id,
     'Dropped' => $dropped,
     'EnrolledOn' => $enrolledOn,
+    'StartChargingOn' => $enrolledOn,
     'DroppedOn' => $droppedOn,
     'Active' => $faker->optional(0.2, 1)->numberBetween($min = 0, $max = 1)
   ];

--- a/database/migrations/2017_10_12_133949_create_enrollments_table.php
+++ b/database/migrations/2017_10_12_133949_create_enrollments_table.php
@@ -20,6 +20,7 @@ class CreateEnrollmentsTable extends Migration
             $table->integer('class_dates_id')->nullable();
             $table->integer('Dropped')->nullable();
             $table->dateTime('EnrolledOn')->nullable();
+            $table->dateTime('StartChargingOn')->nullable();
             $table->dateTime('DroppedOn')->nullable();
             $table->integer('Active')->nullable();
             $table->integer('created_by')->nullable();

--- a/database/migrations/2017_10_12_133949_create_enrollments_table.php
+++ b/database/migrations/2017_10_12_133949_create_enrollments_table.php
@@ -15,12 +15,12 @@ class CreateEnrollmentsTable extends Migration
     {
         Schema::create('enrollments', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('student_id');
-            $table->integer('classes_id');
-            $table->integer('class_dates_id')->nullable();
-            $table->integer('Dropped')->nullable();
+            $table->unsignedInteger('student_id');
+            $table->unsignedInteger('enrollable_id');
+            $table->string('enrollable_type');
             $table->dateTime('EnrolledOn')->nullable();
             $table->dateTime('StartChargingOn')->nullable();
+            $table->integer('Dropped')->nullable();
             $table->dateTime('DroppedOn')->nullable();
             $table->integer('Active')->nullable();
             $table->integer('created_by')->nullable();

--- a/database/migrations/2017_12_27_211100_create_class_dates_table.php
+++ b/database/migrations/2017_12_27_211100_create_class_dates_table.php
@@ -16,7 +16,7 @@ class CreateClassDatesTable extends Migration
         Schema::create('class_dates', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('classes_id');
-            $table->dateTime('HeldOn')->nullable();
+            $table->string('HeldOn')->nullable();
             $table->integer('created_by')->nullable();
             $table->integer('updated_by')->nullable();
             $table->timestamps();

--- a/database/migrations/2018_01_26_132600_create_class_days_table.php
+++ b/database/migrations/2018_01_26_132600_create_class_days_table.php
@@ -16,7 +16,7 @@ class CreateClassDaysTable extends Migration
     Schema::create('class_days', function (Blueprint $table) {
       $table->increments('id');
       $table->unsignedInteger('classes_id');
-      $table->string('DayHeldOn', 100)->nullable();
+      $table->string('HeldOn')->nullable();
       $table->integer('created_by')->nullable();
       $table->integer('updated_by')->nullable();
       $table->timestamps();

--- a/database/seeds/SeasonsTableSeeder.php
+++ b/database/seeds/SeasonsTableSeeder.php
@@ -29,10 +29,10 @@ class SeasonsTableSeeder extends Seeder
                     $rand_keys = array_rand($input, $howManyDays);
                     if (is_array($rand_keys)) {
                         for ($i = 0; $i < $howManyDays; $i++) {
-                            $class->days()->save(factory(App\ClassDay::class)->make(['classes_id' => $class->id, 'DayHeldOn' => $input[$rand_keys[$i]]]));
+                            $class->days()->save(factory(App\ClassDay::class)->make(['classes_id' => $class->id, 'HeldOn' => $input[$rand_keys[$i]]]));
                         }
                     } else {
-                        $class->days()->save(factory(App\ClassDay::class)->make(['classes_id' => $class->id, 'DayHeldOn' => $input[$rand_keys]]));
+                        $class->days()->save(factory(App\ClassDay::class)->make(['classes_id' => $class->id, 'HeldOn' => $input[$rand_keys]]));
                     }
                     
                 }

--- a/resources/views/enrollments/edit.blade.php
+++ b/resources/views/enrollments/edit.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.master')
+
+@section('content')
+<div class="columns">
+  <div class="column is-narrow">
+    @include('students.list')
+  </div>
+  <div class="column is-four-fifths">
+    <div class="container" id="app">
+    <div class="columns is-multiline">
+      <div class="column">
+        <div class="box">
+          <h5 class="title is-5"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
+            Edit enrollment for <a href="{{route('students.edit', ['student' => $enrollment->student->id]) }}"> {{ $enrollment->student->name() }}</a> for 
+            <a href="{{route('classes', ['class' => $enrollment->class->id]) }}"> {{ $enrollment->class->Name }}</a>
+          </h5>
+          <div class="field">
+            <label class="label">Enrolled On</label>
+            <v-date-picker :mode="mode"
+              popover-visibility="focus"
+              class="control"
+              v-model='enrolledDate'
+              style="display:block;">
+                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="enrolledDate">
+            </v-date-picker>
+          </div>
+          <div class="field">
+            <label class="label">Start Charging On</label>
+            <v-date-picker :mode="mode"
+              popover-visibility="focus"
+              class="control"
+              v-model='startChargingDate'
+              style="display:block;">
+                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="startChargingDate">
+            </v-date-picker>
+          </div>
+          <div class="field">
+            <label class="label">Dropped</label>
+            <div class="field">
+              <input class="is-checkradio" id="DroppedYes" type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 1) checked="checked" @endif>
+              <label for="DroppedYes">Yes</label>
+              <input class="is-checkradio" id="DroppedNo" type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 0) checked="checked" @endif>
+              <label for="DroppedNo">No</label>
+            </div>
+          </div>
+          <div class="field">
+            <label class="label">Dropped On</label>
+            <v-date-picker :mode="mode"
+              popover-visibility="focus"
+              class="control"
+              v-model='droppedDate'
+              style="display:block;">
+                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="droppedDate">
+            </v-date-picker>
+          </div>
+          <div class="field">
+            <a href="{{ route('enrollments.update', $enrollment->id) }}" class="button is-primary">Save</a>
+            <a href="{{ route('students.edit', $enrollment->student)}}" class="button is-light">Cancel</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
+<script>
+  var editEnrollment = new Vue({
+    el: '#app',
+			data: {
+          mode: 'single',
+          enrolledDate: moment('{{$enrollment->EnrolledOn}}').toDate(),
+          startChargingDate: moment('{{$enrollment->StartChargingOn}}').toDate(),
+          droppedDate: moment('{{$enrollment->DroppedOn}}').toDate(),
+			},
+  });
+
+
+</script>
+@endsection

--- a/resources/views/enrollments/edit.blade.php
+++ b/resources/views/enrollments/edit.blade.php
@@ -12,8 +12,37 @@
         <div class="box">
           <h5 class="title is-5"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
             Edit enrollment for <a href="{{route('students.edit', ['student' => $enrollment->student->id]) }}"> {{ $enrollment->student->name() }}</a> for 
-            <a href="{{route('classes', ['class' => $enrollment->class->id]) }}"> {{ $enrollment->class->Name }}</a>
+            <a href="{{route('classes', ['class' => $enrollment->enrollable->class->id]) }}"> {{ $enrollment->enrollable->class->Name }}</a>
           </h5>
+          <div class="field" @if ($enrollment->enrollable->class->season->SeasonType == 2) style="display:none;" @endif>
+				<label class="label">Days of the Week</label>
+				<div class="control" >
+					<input class="is-checkradio" type="checkbox" name="monday" id="monday" v-model="monday">
+					<label for="monday">Monday</label>
+					<input class="is-checkradio" type="checkbox" name="tuesday" id="tuesday" v-model="tuesday">
+					<label for="tuesday">Tuesday</label>
+					<input class="is-checkradio" type="checkbox" name="wednesday" id="wednesday" v-model="wednesday">
+					<label for="wednesday">Wednesday</label>
+					<input class="is-checkradio" type="checkbox" name="thursday" id="thursday" v-model="thursday">
+					<label for="thursday">Thursday</label>
+					<input class="is-checkradio" type="checkbox" name="friday" id="friday" v-model="friday">
+					<label for="friday">Friday</label>
+					<input class="is-checkradio" type="checkbox" name="saturday" id="saturday" v-model="saturday">
+					<label for="saturday">Saturday</label>
+					<input class="is-checkradio" type="checkbox" name="sunday" id="sunday" v-model="sunday">
+					<label for="sunday">Sunday</label>
+				</div>
+			</div>
+			<div class="field" @if ($enrollment->enrollable->class->season->SeasonType == 1) style="display:none;" @endif>
+				<label class="label">Occurs On</label>
+					<v-date-picker :mode='multipleSelectMode' 
+						v-model='dateSpecificDates' 
+						popover-visibility="focus"
+						class="control"
+						style="display:block;">
+							<input slot-scope='props' :value='props.inputValue' class="input" type="text" v.model="dateSpecificDates" name="dateSpecificDates">
+					</v-date-picker>
+			</div>
           <div class="field">
             <label class="label">Enrolled On</label>
             <v-date-picker :mode="mode"
@@ -37,9 +66,9 @@
           <div class="field">
             <label class="label">Dropped</label>
             <div class="field">
-              <input class="is-checkradio" id="DroppedYes" type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 1) checked="checked" @endif>
+              <input class="is-checkradio" id="DroppedYes" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 1) checked="checked" @endif>
               <label for="DroppedYes">Yes</label>
-              <input class="is-checkradio" id="DroppedNo" type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 0) checked="checked" @endif>
+              <input class="is-checkradio" id="DroppedNo" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 0) checked="checked" @endif>
               <label for="DroppedNo">No</label>
             </div>
           </div>
@@ -50,7 +79,7 @@
               class="control"
               v-model='droppedDate'
               style="display:block;">
-                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="droppedDate">
+                <input slot-scope='props' :value='props.inputValue' disabled class="input" type="text" name="droppedDate">
             </v-date-picker>
           </div>
           <div class="field">
@@ -68,9 +97,18 @@
     el: '#app',
 			data: {
           mode: 'single',
+          multipleSelectMode: 'multiple',
           enrolledDate: moment('{{$enrollment->EnrolledOn}}').toDate(),
           startChargingDate: moment('{{$enrollment->StartChargingOn}}').toDate(),
           droppedDate: moment('{{$enrollment->DroppedOn}}').toDate(),
+          dateSpecificDates: '{{$enrollment->enrollable->HeldOn}}',
+          monday: '',
+          tuesday: '',
+          wednesday: '',
+          thursday: '',
+          friday: '',
+          saturday: '',
+          sunday: ''
 			},
   });
 

--- a/resources/views/enrollments/edit.blade.php
+++ b/resources/views/enrollments/edit.blade.php
@@ -9,84 +9,62 @@
     <div class="container" id="app">
     <div class="columns is-multiline">
       <div class="column">
-        <div class="box">
-          <h5 class="title is-5"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
-            Edit enrollment for <a href="{{route('students.edit', ['student' => $enrollment->student->id]) }}"> {{ $enrollment->student->name() }}</a> for 
-            <a href="{{route('classes', ['class' => $enrollment->enrollable->class->id]) }}"> {{ $enrollment->enrollable->class->Name }}</a>
-          </h5>
-          <div class="field" @if ($enrollment->enrollable->class->season->SeasonType == 2) style="display:none;" @endif>
-				<label class="label">Days of the Week</label>
-				<div class="control" >
-					<input class="is-checkradio" type="checkbox" name="monday" id="monday" v-model="monday">
-					<label for="monday">Monday</label>
-					<input class="is-checkradio" type="checkbox" name="tuesday" id="tuesday" v-model="tuesday">
-					<label for="tuesday">Tuesday</label>
-					<input class="is-checkradio" type="checkbox" name="wednesday" id="wednesday" v-model="wednesday">
-					<label for="wednesday">Wednesday</label>
-					<input class="is-checkradio" type="checkbox" name="thursday" id="thursday" v-model="thursday">
-					<label for="thursday">Thursday</label>
-					<input class="is-checkradio" type="checkbox" name="friday" id="friday" v-model="friday">
-					<label for="friday">Friday</label>
-					<input class="is-checkradio" type="checkbox" name="saturday" id="saturday" v-model="saturday">
-					<label for="saturday">Saturday</label>
-					<input class="is-checkradio" type="checkbox" name="sunday" id="sunday" v-model="sunday">
-					<label for="sunday">Sunday</label>
-				</div>
-			</div>
-			<div class="field" @if ($enrollment->enrollable->class->season->SeasonType == 1) style="display:none;" @endif>
-				<label class="label">Occurs On</label>
-					<v-date-picker :mode='multipleSelectMode' 
-						v-model='dateSpecificDates' 
-						popover-visibility="focus"
-						class="control"
-						style="display:block;">
-							<input slot-scope='props' :value='props.inputValue' class="input" type="text" v.model="dateSpecificDates" name="dateSpecificDates">
-					</v-date-picker>
-			</div>
-          <div class="field">
-            <label class="label">Enrolled On</label>
-            <v-date-picker :mode="mode"
-              popover-visibility="focus"
-              class="control"
-              v-model='enrolledDate'
-              style="display:block;">
-                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="enrolledDate">
-            </v-date-picker>
-          </div>
-          <div class="field">
-            <label class="label">Start Charging On</label>
-            <v-date-picker :mode="mode"
-              popover-visibility="focus"
-              class="control"
-              v-model='startChargingDate'
-              style="display:block;">
-                <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="startChargingDate">
-            </v-date-picker>
-          </div>
-          <div class="field">
-            <label class="label">Dropped</label>
+        <form method="POST" action="{{ route('enrollments.update', $enrollment->id) }}">
+          @csrf
+          <div class="box">
+            <h5 class="title is-5"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
+              Edit enrollment for <a href="{{route('students.edit', ['student' => $enrollment->student->id]) }}"> {{ $enrollment->student->name() }}</a> for 
+              <a href="{{route('classes', ['class' => $enrollment->enrollable->class->id]) }}"> {{ $enrollment->enrollable->class->Name }}</a>
+            </h5>
+            <label class="label">Held On</label>
+            <div class="field" >
+              <input class="input" type="text" name="HeldOn" value="{{$enrollment->enrollable->HeldOn}}" disabled>
+            </div>
             <div class="field">
-              <input class="is-checkradio" id="DroppedYes" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 1) checked="checked" @endif>
-              <label for="DroppedYes">Yes</label>
-              <input class="is-checkradio" id="DroppedNo" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 0) checked="checked" @endif>
-              <label for="DroppedNo">No</label>
+              <label class="label">Enrolled On</label>
+              <v-date-picker :mode="mode"
+                popover-visibility="focus"
+                class="control"
+                v-model='EnrolledOn'
+                style="display:block;">
+                  <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="EnrolledOn">
+              </v-date-picker>
+            </div>
+            <div class="field">
+              <label class="label">Start Charging On</label>
+              <v-date-picker :mode="mode"
+                popover-visibility="focus"
+                class="control"
+                v-model='StartChargingOn'
+                style="display:block;">
+                  <input slot-scope='props' :value='props.inputValue' class="input" type="text" name="StartChargingOn">
+              </v-date-picker>
+            </div>
+            <div class="field">
+              <label class="label">Dropped</label>
+              <div class="field">
+                <input class="is-checkradio" id="DroppedYes" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 1) checked="checked" @endif>
+                <label for="DroppedYes">Yes</label>
+                <input class="is-checkradio" id="DroppedNo" disabled type="radio" name="exampleRadioInline" @if ($enrollment->Dropped == 0) checked="checked" @endif>
+                <label for="DroppedNo">No</label>
+              </div>
+            </div>
+            <div class="field">
+              <label class="label">Dropped On</label>
+              <v-date-picker :mode="mode"
+                popover-visibility="focus"
+                class="control"
+                v-model='droppedDate'
+                style="display:block;">
+                  <input slot-scope='props' :value='props.inputValue' disabled class="input" type="text" name="droppedDate">
+              </v-date-picker>
+            </div>
+            <div class="field">
+              <button type="submit" class="button is-primary">Save</button>
+              <a href="{{ route('students.edit', $enrollment->student)}}" class="button is-light">Cancel</a>
             </div>
           </div>
-          <div class="field">
-            <label class="label">Dropped On</label>
-            <v-date-picker :mode="mode"
-              popover-visibility="focus"
-              class="control"
-              v-model='droppedDate'
-              style="display:block;">
-                <input slot-scope='props' :value='props.inputValue' disabled class="input" type="text" name="droppedDate">
-            </v-date-picker>
-          </div>
-          <div class="field">
-            <a href="{{ route('enrollments.update', $enrollment->id) }}" class="button is-primary">Save</a>
-            <a href="{{ route('students.edit', $enrollment->student)}}" class="button is-light">Cancel</a>
-          </div>
-        </div>
+        </form>
       </div>
     </div>
   </div>
@@ -98,20 +76,12 @@
 			data: {
           mode: 'single',
           multipleSelectMode: 'multiple',
-          enrolledDate: moment('{{$enrollment->EnrolledOn}}').toDate(),
-          startChargingDate: moment('{{$enrollment->StartChargingOn}}').toDate(),
+          EnrolledOn: moment('{{$enrollment->EnrolledOn}}').toDate(),
+          StartChargingOn: moment('{{$enrollment->StartChargingOn}}').toDate(),
           droppedDate: moment('{{$enrollment->DroppedOn}}').toDate(),
-          dateSpecificDates: '{{$enrollment->enrollable->HeldOn}}',
-          monday: '',
-          tuesday: '',
-          wednesday: '',
-          thursday: '',
-          friday: '',
-          saturday: '',
-          sunday: ''
+          dateSpecificDates: [moment('{{$enrollment->enrollable->HeldOn}}').toDate()]
 			},
   });
-
 
 </script>
 @endsection

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -33,8 +33,8 @@
           <div class="select">
             <select name="Sex">
               <option>Choose a gender</option>
-              <option @if ($student->gender() == 1) selected @endif value="1">Female</option>
-              <option @if ($student->gender() == 2) selected @endif value="2">Male</option>
+              <option @if ($student->gender() == 'F') selected @endif value="1">Female</option>
+              <option @if ($student->gender() == 'M') selected @endif value="2">Male</option>
             </select>
           </div>
         </div>

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -61,7 +61,11 @@
           <thead>
             <th>Class Name</th>
             <th>Days Enrolled</th>
-            <th>Enrollment Added</th>
+            <th>Enrollment On</th>
+            <th>Start Charging On</th>
+            <th>Dropped?</th>
+            <th>Dropped On</th>
+            <th></th>
           </thead>
           @foreach($student->enrollments as $enrollment)
           <tr>
@@ -74,10 +78,21 @@
                 {{$classday->DayHeldOn}}
               @endforeach
             </td>
-            <td>{{$enrollment->friendlyDate($enrollment->EnrolledOn)}}</td>  
+            <td>{{$enrollment->friendlyDate($enrollment->EnrolledOn)}}</td>
+            <td>{{$enrollment->friendlyDate($enrollment->StartChargingOn)}}</td>
+            <td>{{$enrollment->Dropped}}</td>
+            <td>{{$enrollment->friendlyDate($enrollment->DroppedOn)}}</td>
+            <td>
+              <a class="button is-primary" href="{{ route('enrollments.edit', $enrollment->id) }}">Edit</a>
+              <a class="button is-primary" href="{{ route('enrollments.delete', $enrollment->id) }}">Drop</a>
+              <a class="button is-primary" href="{{ route('enrollments.switch', $enrollment->id) }}">Switch</a>
+            </td>
           </tr>
           @endforeach
         </table>
+        <div class="control">
+            <a class="button is-primary" href="#">Add Enrollment</a>
+          </div>
         
       </div>
     </div>

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -69,14 +69,15 @@
           </thead>
           @foreach($student->enrollments as $enrollment)
           <tr>
-            <td><a href="{{ route('classes.show', $enrollment->class->id) }}">{{$enrollment->class->Name}}</a></td>
+            <td><a href="{{ route('classes.show', $enrollment->enrollable->class->id) }}">{{$enrollment->enrollable->class->Name}}</a></td>
             <td>
-              @if (isset($enrollment->class_dates_id))
-                {{$enrollment->friendlyDate($enrollment->date->HeldOn)}}
+              @if ($enrollment->enrollable_type == 'App\ClassDate')
+                {{$enrollment->friendlyDate($enrollment->enrollable->HeldOn)}}
               @endif
-              @foreach($enrollment->class->days as $classday)
-                {{$classday->DayHeldOn}}
-              @endforeach
+              @if ($enrollment->enrollable_type == 'App\ClassDay')
+                {{$enrollment->enrollable->HeldOn}}
+              @endif
+
             </td>
             <td>{{$enrollment->friendlyDate($enrollment->EnrolledOn)}}</td>
             <td>{{$enrollment->friendlyDate($enrollment->StartChargingOn)}}</td>

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -72,14 +72,10 @@
             <td><a href="{{ route('classes.show', $enrollment->enrollable->class->id) }}">{{$enrollment->enrollable->class->Name}}</a></td>
             <td>
               @if ($enrollment->enrollable_type == 'App\ClassDate')
-                @foreach($enrollment->otherEnrollmentsInClass($enrollment) as $otherenrollment)
-                  {{$enrollment->friendlyDate($otherenrollment->HeldOn)}}
-                @endforeach
+                {{$enrollment->friendlyDate($enrollment->enrollable->HeldOn)}}
               @endif
               @if ($enrollment->enrollable_type == 'App\ClassDay')
-                @foreach($enrollment->otherEnrollmentsInClass($enrollment) as $otherenrollment)
-                  {{$otherenrollment->HeldOn}}
-                @endforeach
+                {{$enrollment->enrollable->HeldOn}}
               @endif
 
             </td>

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -72,10 +72,14 @@
             <td><a href="{{ route('classes.show', $enrollment->enrollable->class->id) }}">{{$enrollment->enrollable->class->Name}}</a></td>
             <td>
               @if ($enrollment->enrollable_type == 'App\ClassDate')
-                {{$enrollment->friendlyDate($enrollment->enrollable->HeldOn)}}
+                @foreach($enrollment->otherEnrollmentsInClass($enrollment) as $otherenrollment)
+                  {{$enrollment->friendlyDate($otherenrollment->HeldOn)}}
+                @endforeach
               @endif
               @if ($enrollment->enrollable_type == 'App\ClassDay')
-                {{$enrollment->enrollable->HeldOn}}
+                @foreach($enrollment->otherEnrollmentsInClass($enrollment) as $otherenrollment)
+                  {{$otherenrollment->HeldOn}}
+                @endforeach
               @endif
 
             </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,10 +36,28 @@ Route::middleware(['auth'])->group(function () {
       'as' => 'students.store',
       'uses' => 'StudentsController@store'
   ]);
-    Route::post('/students/{student}', [
-        'as' => 'students.update',
-        'uses' => 'StudentsController@update'
-    ]);
+  Route::post('/students/{student}', [
+      'as' => 'students.update',
+      'uses' => 'StudentsController@update'
+  ]);
+
+  //Enrollment routes
+  Route::get('/enrollments/{enrollment}', [
+    'as' => 'enrollments.edit',
+    'uses' => 'EnrollmentsController@edit'
+  ]);
+  Route::post('/enrollments/{enrollment}/delete', [
+    'as' => 'enrollments.delete',
+    'uses' => 'EnrollmentsController@destroy'
+  ]);
+  Route::post('/enrollments/{enrollment}', [
+    'as' => 'enrollments.update',
+    'uses' => 'EnrollmentsController@update'
+  ]);
+  Route::post('/enrollments/{enrollment}/switch', [
+    'as' => 'enrollments.switch',
+    'uses' => 'EnrollmentsController@update'
+  ]);
 
   //Class routes
   Route::get('/classes', [

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,7 @@ Route::middleware(['auth'])->group(function () {
     'as' => 'enrollments.edit',
     'uses' => 'EnrollmentsController@edit'
   ]);
-  Route::post('/enrollments/{enrollment}/delete', [
+  Route::get('/enrollments/{enrollment}/delete', [
     'as' => 'enrollments.delete',
     'uses' => 'EnrollmentsController@destroy'
   ]);


### PR DESCRIPTION
Made enrollments polymorphic with classdays and dates, rather then storing the ID on the enrollment. For editing, it made the most sense to keep it per-enrollment, rather then treating the "group" of enrollments the same, since a student could take Monday for a few months and then start taking Thursday as well. 